### PR TITLE
DateTime immutable doesn't use formatted timezone

### DIFF
--- a/src/DateTimeMock/DateTimeImmutableMock.php
+++ b/src/DateTimeMock/DateTimeImmutableMock.php
@@ -17,6 +17,6 @@ class DateTimeImmutableMock extends \DateTimeImmutable
         // Just use the mutable version of the mock, so we don't have to replicate freezing logic.
         $otherDateTime = new DateTimeMock($datetime, $timezone);
 
-        parent::__construct($otherDateTime->format('Y-m-d H:i:s.u'), $timezone);
+        parent::__construct($otherDateTime->format('Y-m-d\TH:i:s.uT'), $timezone);
     }
 }

--- a/tests/ClockMockTest.php
+++ b/tests/ClockMockTest.php
@@ -38,6 +38,15 @@ class ClockMockTest extends TestCase
         $this->assertEquals($juneFifth1986, new \DateTimeImmutable('1986-06-05'));
     }
 
+    public function test_DateTimeImmutable_constructor_with_timezone()
+    {
+        $dateWithTimezone = new \DateTimeImmutable('1986-06-05 14:41:32+02:00');
+        
+        ClockMock::freeze($fakeNow = new \DateTimeImmutable('now'));
+
+        $this->assertEquals($dateWithTimezone, new \DateTimeImmutable('1986-06-05 14:41:32+02:00'));
+    }
+    
     public function test_DateTime_constructor_with_absolute_mocked_date()
     {
         ClockMock::freeze($fakeNow = new \DateTime('1986-06-05'));


### PR DESCRIPTION
DateTimeImmutableMock is created by formatting a new DateTimeMock, and thus avoiding code duplication.

However, sometimes the timezone can be passed in the date format (for example: "2022-03-15 14:06:30+02:00").

The previous format used to create the immutable date from the mutable one (which was "Y-m-d H:i:s.u") doesn't include the date timezone. 
Because of this, the timezone of the immutable date is lost when it is passed in a formatted date.