### PR TITLE
fix: add support for create from epoch

### DIFF
--- a/src/ClockMock.php
+++ b/src/ClockMock.php
@@ -165,7 +165,7 @@ final class ClockMock
      */
     private static function mock_date_create_from_format(): callable
     {
-        return function ($format, $datetime, DateTimeZone $timezone = null) {
+        return function (string $format, string $datetime, DateTimeZone $timezone = null) {
             $dateTimeObject = \DateTime::createFromFormat($format, $datetime, $timezone);
 
             $parsedDate = date_parse($datetime);
@@ -174,7 +174,7 @@ final class ClockMock
                 $parsedDate['hour'] === false ? idate('H') : $parsedDate['hour'],
                 $parsedDate['minute'] === false ? idate('i') : $parsedDate['minute'],
                 $parsedDate['second'] === false ? idate('s') : $parsedDate['second'],
-                $parsedDate['fraction'] === false ? (int) date('u') : $parsedDate['fraction'],
+                $parsedDate['fraction'] === false ? (int) date('u') : (int) $parsedDate['fraction'],
             );
         };
     }

--- a/tests/ClockMockTest.php
+++ b/tests/ClockMockTest.php
@@ -61,7 +61,16 @@ class ClockMockTest extends TestCase
         // Verification: when not provided with a time, createFromFormat should use current time.
         $this->assertSame('2022-05-28 12:13:14', $dateTimeFromFormat->format('Y-m-d H:i:s'));
     }
-    
+
+    public function test_DateTime_createFromFormat_epoch()
+    {
+        ClockMock::freeze(new \DateTimeImmutable('1986-06-05 12:13:14'));
+
+        $dateTimeFromFormat = \DateTime::createFromFormat('U', strval(time()));
+
+        $this->assertSame('1986-06-05 12:13:14', $dateTimeFromFormat->format('Y-m-d H:i:s'));
+    }
+
     public function test_DateTime_constructor_with_absolute_mocked_date()
     {
         ClockMock::freeze($fakeNow = new \DateTime('1986-06-05'));


### PR DESCRIPTION
Fixes https://github.com/slope-it/clock-mock/issues/17 

Its pretty common with Symfonys time mocking to do `\DateTime::createFromFormat('U', strval(time()));`  re: strict types Ive added the types otherwise you just get a type error from the `int` on `time()` also downstream from dateparse.


<img width="842" alt="Screenshot 2022-06-08 at 17 00 35" src="https://user-images.githubusercontent.com/319498/172663701-d682334b-2129-451e-bece-9c85eae1801b.png">

