### PR TITLE
Fix microtime(false) return value format

### DIFF
--- a/src/ClockMock.php
+++ b/src/ClockMock.php
@@ -324,8 +324,7 @@ final class ClockMock
             if ($as_float) {
                 return (float) self::$frozenDateTime->format('U.u');
             }
-
-            return self::$frozenDateTime->format('0.u U');
+            return self::$frozenDateTime->format('0.u00 U');
         };
 
         return fn (bool $as_float = false) => $microtime_mock($as_float);

--- a/tests/ClockMockTest.php
+++ b/tests/ClockMockTest.php
@@ -349,7 +349,7 @@ class ClockMockTest extends TestCase
     {
         ClockMock::freeze(new \DateTime('@1619000631.123456'));
 
-        $this->assertEquals('0.123456 1619000631', microtime());
+        $this->assertEquals('0.12345600 1619000631', microtime());
         $this->assertSame(1619000631.123456, microtime(true));
     }
 


### PR DESCRIPTION
Align msec fragment of `microsecond(false)` return value to have a 8 digits long decimal part

Ref: https://3v4l.org/ghA3i