### PR TITLE
34: Fix datetimeimmutable not respecting timezone type

### DIFF
--- a/src/ClockMock.php
+++ b/src/ClockMock.php
@@ -211,7 +211,7 @@ final class ClockMock
             // Create an immutable instance starting from the mutable mock, so we don't have to replicate mocking logic.
             $mutableDateTime = date_create_from_format($format, $datetime, $timezone);
 
-            return new \DateTimeImmutable($mutableDateTime->format('Y-m-d\TH:i:s.uT'), $timezone);
+            return new \DateTimeImmutable($mutableDateTime->format('Y-m-d\TH:i:s.u'), $mutableDateTime->getTimezone());
         };
     }
 

--- a/src/DateTimeMock/DateTimeImmutableMock.php
+++ b/src/DateTimeMock/DateTimeImmutableMock.php
@@ -17,6 +17,6 @@ class DateTimeImmutableMock extends \DateTimeImmutable
         // Create an immutable instance starting from the mutable mock, so we don't have to replicate mocking logic.
         $mutableDateTime = new DateTimeMock($datetime, $timezone);
 
-        parent::__construct($mutableDateTime->format('Y-m-d\TH:i:s.uT'), $timezone);
+        parent::__construct($mutableDateTime->format('Y-m-d\TH:i:s.u'), $mutableDateTime->getTimezone());
     }
 }

--- a/tests/ClockMockTest.php
+++ b/tests/ClockMockTest.php
@@ -52,6 +52,37 @@ class ClockMockTest extends TestCase
         $this->assertEquals($dateWithTimezone, new \DateTimeImmutable('1986-06-05 14:41:32+02:00'));
     }
 
+    public function test_DateTimeImmutable_constructor_with_timezone_respect_zone_type()
+    {
+        ClockMock::freeze(new \DateTimeImmutable('now'));
+
+        $timezoneType3 = 'Asia/Tokyo';
+        $date = new \DateTimeImmutable('1986-06-05', new \DateTimeZone($timezoneType3));
+
+        $this->assertEquals($date->getTimezone()->getName(), $timezoneType3);
+
+        $timezoneType2 = 'CDT';
+        $date = new \DateTimeImmutable('1986-06-05', new \DateTimeZone($timezoneType2));
+
+        $this->assertEquals($date->getTimezone()->getName(), $timezoneType2);
+    }
+
+    public function test_DateTimeImmutable_constructor_without_timezone()
+    {
+        $originalTimezone = date_default_timezone_get();
+
+        $defaultTimezone = 'Asia/Tokyo';
+        date_default_timezone_set($defaultTimezone);
+
+        ClockMock::freeze(new \DateTimeImmutable('1986-06-05'));
+
+        $newDate = new \DateTimeImmutable('1986-06-05');
+
+        $this->assertEquals($newDate->getTimezone()->getName(), $defaultTimezone);
+
+        date_default_timezone_set($originalTimezone); // Revert timezone.
+    }
+
     public function test_DateTimeImmutable_createFromFormat()
     {
         ClockMock::freeze(new \DateTimeImmutable('1986-06-05 12:13:14'));

--- a/tests/ClockMockTest.php
+++ b/tests/ClockMockTest.php
@@ -70,17 +70,18 @@ class ClockMockTest extends TestCase
     public function test_DateTimeImmutable_constructor_without_timezone()
     {
         $originalTimezone = date_default_timezone_get();
-
         $defaultTimezone = 'Asia/Tokyo';
         date_default_timezone_set($defaultTimezone);
 
-        ClockMock::freeze(new \DateTimeImmutable('1986-06-05'));
+        try {
+            ClockMock::freeze(new \DateTimeImmutable('1986-06-05'));
 
-        $newDate = new \DateTimeImmutable('1986-06-05');
+            $newDate = new \DateTimeImmutable('1986-06-05');
 
-        $this->assertEquals($newDate->getTimezone()->getName(), $defaultTimezone);
-
-        date_default_timezone_set($originalTimezone); // Revert timezone.
+            $this->assertEquals($newDate->getTimezone()->getName(), $defaultTimezone);
+        } finally {
+            date_default_timezone_set($originalTimezone); // Revert timezone.
+        }
     }
 
     public function test_DateTimeImmutable_createFromFormat()


### PR DESCRIPTION
PR to fix issue #34 where dates constructed with `DateTimeImmutable` after `freeze` do not respect the timezone type when using the default timezone or when specifying it in the constructor.

The problem boils down to the use of `$mutableDateTime->format('Y-m-d\TH:i:s.uT');` where `T` result in `DateTimeImmutable` always using the abbreviated timezone of type 2.

This PR contains the following changes:
- Change to remove `T` in format, i.e. use `Y-m-d\TH:i:s.u`, and construct `DateTimeImmutable` with the mutable `DateTimeMock` timezone.
- Adds two tests:
 - `test_DateTimeImmutable_constructor_without_timezone`
 - `test_DateTimeImmutable_constructor_with_timezone_respect_zone_type`

### Test Cases
```php
date_default_timezone_set('Canada/Central');

ClockMock::freeze($fakeNow = new \DateTimeImmutable('now'));

// DateTimeImmutable assertions

$date = new \DateTimeImmutable('now');
assert($date->getTimezone()->getName() === $defaultTimezone, 'match timezone');

$date = new \DateTimeImmutable('now', new DateTimeZone('Asia/Tokyo'));
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTimeImmutable('2023-03-13');
assert($date->getTimezone()->getName() === $defaultTimezone, 'match timezone');

$date = new \DateTimeImmutable('2023-03-13', new DateTimeZone('Asia/Tokyo'));
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTimeImmutable('2023-03-01T23:00:00.000000+05:00');
assert($date->getTimezone()->getName() === '+05:00', 'match timezone');

$date = new \DateTimeImmutable('2023-03-01T23:00:00.000000+05:00', new DateTimeZone('Canada/Central'));
assert($date->getTimezone()->getName() === '+05:00', 'match timezone');

$date = new \DateTimeImmutable('2023-03-01T23:00:00.000000 Asia/Tokyo');
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTimeImmutable('2023-03-01T23:00:00.000000 Asia/Tokyo', new DateTimeZone('Canada/Central'));
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTimeImmutableMock('2023-03-01T23:00:00.000000CDT');
assert($date->getTimezone()->getName() === 'CDT', 'match timezone');

$date = new \DateTimeImmutableMock('2023-03-01T23:00:00.000000CDT', new DateTimeZone('Asia/Tokyo'));
assert($date->getTimezone()->getName() === 'CDT', 'match timezone');

// DateTime assertions

$date = new \DateTime('now');
assert($date->getTimezone()->getName() === $defaultTimezone, 'match timezone');

$date = new \DateTime('now', new DateTimeZone('Asia/Tokyo'));
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTime('2023-03-13');
assert($date->getTimezone()->getName() === $defaultTimezone, 'match timezone');

$date = new \DateTime('2023-03-13', new DateTimeZone('Asia/Tokyo'));
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTime('2023-03-01T23:00:00.000000+05:00');
assert($date->getTimezone()->getName() === '+05:00', 'match timezone');

$date = new \DateTime('2023-03-01T23:00:00.000000+05:00', new DateTimeZone('Canada/Central'));
assert($date->getTimezone()->getName() === '+05:00', 'match timezone');

$date = new \DateTime('2023-03-01T23:00:00.000000 Asia/Tokyo');
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTime('2023-03-01T23:00:00.000000 Asia/Tokyo', new DateTimeZone('Canada/Central'));
assert($date->getTimezone()->getName() === 'Asia/Tokyo', 'match timezone');

$date = new \DateTime('2023-03-01T23:00:00.000000CDT');
assert($date->getTimezone()->getName() === 'CDT', 'match timezone');

$date = new \DateTime('2023-03-01T23:00:00.000000CDT', new DateTimeZone('Asia/Tokyo'));
assert($date->getTimezone()->getName() === 'CDT', 'match timezone');
```
