### PR TITLE
fix create from format with invalid format

### DIFF
--- a/src/ClockMock.php
+++ b/src/ClockMock.php
@@ -223,13 +223,15 @@ final class ClockMock
             // Create an immutable instance starting from the mutable mock, so we don't have to replicate mocking logic.
             $mutableDateTime = date_create_from_format($format, $datetime, $timezone);
 
-            return $mutableDateTime
-                ? new \DateTimeImmutable(
-                    $mutableDateTime->format('Y-m-d\TH:i:s.u'),
-                    $mutableDateTime->getTimezone()
-                )
-                : false
-            ;
+            // $mutableDateTime may be false if the format passed to createDateFromFormat() does not match the supplied date string
+            if (false === $mutableDateTime) {
+                return false;
+            }
+
+            return new \DateTimeImmutable(
+                $mutableDateTime->format('Y-m-d\TH:i:s.u'),
+                $mutableDateTime->getTimezone()
+            );
         };
     }
 

--- a/src/ClockMock.php
+++ b/src/ClockMock.php
@@ -223,7 +223,13 @@ final class ClockMock
             // Create an immutable instance starting from the mutable mock, so we don't have to replicate mocking logic.
             $mutableDateTime = date_create_from_format($format, $datetime, $timezone);
 
-            return new \DateTimeImmutable($mutableDateTime->format('Y-m-d\TH:i:s.u'), $mutableDateTime->getTimezone());
+            return $mutableDateTime
+                ? new \DateTimeImmutable(
+                    $mutableDateTime->format('Y-m-d\TH:i:s.u'),
+                    $mutableDateTime->getTimezone()
+                )
+                : false
+            ;
         };
     }
 

--- a/tests/ClockMockTest.php
+++ b/tests/ClockMockTest.php
@@ -269,6 +269,15 @@ class ClockMockTest extends TestCase
         $this->assertSame('2022-05-28 12:13:14', $dateTimeFromFormat->format('Y-m-d H:i:s'));
     }
 
+    public function test_date_create_immutable_from_format_with_invalid_format()
+    {
+        ClockMock::freeze(new \DateTimeImmutable('1986-06-05 12:13:14'));
+
+        $dateTimeFromFormat = date_create_immutable_from_format('d/m/Y', '2022-05-28');
+
+        $this->assertFalse($dateTimeFromFormat);
+    }
+
     public function test_date_create_from_format_freeze_reset_must_not_use_mock()
     {
         ClockMock::freeze(new \DateTimeImmutable('1986-06-05 12:13:14'));


### PR DESCRIPTION
e.g : date_create_immutable_from_format('d/m/Y', '2022-05-28')

return false instead of throwing an exception