### PR TITLE
fix: Undefined array key "REQUEST_TIME_FLOAT" in `ClockMock::freeze()`

### DIFF
--- a/src/ClockMock.php
+++ b/src/ClockMock.php
@@ -47,7 +47,7 @@ final class ClockMock
 
         // When freezing, only store $_SERVER['REQUEST_TIME_FLOAT'] the first time (i.e. when the property is null).
         // This way we will restore the actual original value even after freezing multiple times in a row.
-        if (self::$originalServerRequestTimeFloat === null) {
+        if (self::$originalServerRequestTimeFloat === null && isset($_SERVER['REQUEST_TIME_FLOAT'])) {
             self::$originalServerRequestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'];
         }
 


### PR DESCRIPTION
`ClockMock::freeze()` stores `$_SERVER['REQUEST_TIME_FLOAT']` for later rollback in `ClockMock::reset()`. However, if `$_SERVER['REQUEST_TIME_FLOAT']` is not defined, the code causes an `Undefined array key "REQUEST_TIME_FLOAT"` error.

This PR fixes the issue by adding a check for `$_SERVER['REQUEST_TIME_FLOAT'` before storing the value.

Thanks.